### PR TITLE
feat: add CLI interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,10 +535,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -618,6 +734,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -761,19 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1021,19 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.9",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e5335674a3a259527f97e9176a3767dcc9b220b8e29d643daeb2d6c72caf8b"
+dependencies = [
+ "chrono",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1346,10 +1471,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
+name = "iana-time-zone"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "idna"
@@ -1423,15 +1566,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.13"
+name = "is_terminal_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1471,6 +1609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1791,6 +1938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,16 +2295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
 ]
 
 [[package]]
@@ -2384,15 +2536,18 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "auto-launch",
+ "clap",
  "confy",
+ "directories",
+ "flexi_logger",
  "hidapi",
  "image",
  "log",
  "notify-rust",
- "pretty_env_logger",
  "serde",
  "tao",
  "tray-icon",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2621,6 +2776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,8 +2849,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -2719,7 +2880,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml",
  "thiserror 2.0.17",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -2734,15 +2895,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -3030,6 +3182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "v_frame"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,11 +3333,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -3188,7 +3358,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3200,8 +3379,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3210,9 +3402,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -3255,8 +3458,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3269,12 +3482,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3401,6 +3632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,29 +19,27 @@ incremental = true
 codegen-units = 16
 
 [dependencies]
-# Communicate with HID devices
-hidapi = "2.6.4"
-
-# Logging
+# Logging & Error Handling
 log = "0.4.29"
-pretty_env_logger = "0.5.0"
-
-# Event Loop and Tray Icon
-tao = "0.34.5"
-tray-icon = "0.21.3"
-
-# Config & Serialization
-serde = { version = "1.0", features = ["derive"] }
-confy = "2.0.0"
-
-# Error Handling
+flexi_logger = "0.31.7"
 anyhow = "1.0"
 
-# Autostart
+# Configuration, Data & CLI
+serde = { version = "1.0", features = ["derive"] }
+confy = "2.0.0"
+directories = "6.0.0"
+clap = { version = "4.5.54", features = ["derive"] }
+
+# UI & Desktop Integration
+tao = "0.34.5"
+tray-icon = "0.21.3"
+notify-rust = "4.11.7"
 auto-launch = "0.5.0"
 
-# Image manipulation
+# Hardware & Media
+hidapi = "2.6.4"
 image = "0.25.9"
 
-# Desktop notifications
-notify-rust = "4.11.7"
+# Windows specific dependencies
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62.2", features = ["Win32_System_Console"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,40 @@
+use clap::Parser;
+
+use crate::{config::LogLevel, logger::LogMode};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Set a log level (overrides config).
+    #[arg(long, value_name = "LEVEL")]
+    pub log_level: Option<LogLevel>,
+
+    /// Run a quick diagnostic check and exit.
+    /// This will try to initialize the driver, list connected devices, and print their status to the console.
+    #[arg(long)]
+    pub check: bool,
+
+    /// Print udev rules for Linux and exit.
+    #[arg(long)]
+    #[cfg(target_os = "linux")]
+    pub print_udev_rules: bool,
+}
+
+impl Args {
+    pub fn parse() -> Self {
+        <Self as Parser>::parse()
+    }
+
+    pub fn log_mode(&self) -> LogMode {
+        #[cfg(target_os = "linux")]
+        if self.print_udev_rules {
+            return LogMode::ConsoleOnly;
+        }
+
+        if self.check {
+            return LogMode::ConsoleOnly;
+        }
+
+        LogMode::FileAndConsole
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,35 @@
+use clap::ValueEnum;
 use razer_battery_report::DeviceType;
 use serde::{Deserialize, Serialize};
 
 /// Application name used for configuration directory resolution.
 const APP_NAME: &str = "razer-battery-report";
+
+/// Log levels supported by the application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            LogLevel::Off => "off",
+            LogLevel::Error => "error",
+            LogLevel::Warn => "warn",
+            LogLevel::Info => "info",
+            LogLevel::Debug => "debug",
+            LogLevel::Trace => "trace",
+        };
+        write!(f, "{}", s)
+    }
+}
 
 /// Configuration structure holding user preferences.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -25,6 +52,9 @@ pub struct AppConfig {
 
     /// The device manually selected by the user to be shown in the tray.
     pub preferred_device: Option<DeviceType>,
+
+    /// The logging level (off, error, warn, info, debug, trace).
+    pub log_level: LogLevel,
 }
 
 /// Default values for the configuration.
@@ -37,6 +67,7 @@ impl Default for AppConfig {
             low_battery_threshold: 15,
             critical_battery_threshold: 5,
             preferred_device: None,
+            log_level: LogLevel::Info,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 use hidapi::HidApi;
 use hidapi::HidDevice;
 use hidapi::HidError;
+use log::debug;
 use serde::Deserialize;
 use serde::Serialize;
 use std::error::Error;
@@ -103,14 +104,14 @@ impl Razer {
             .collect();
 
         if device_ids.is_empty() {
-            println!("No Razer devices currently connected.");
+            eprintln!("No Razer devices currently connected.");
             return;
         }
 
-        println!("# Razer Device Permissions");
-        println!("# Save this to /etc/udev/rules.d/99-razer.rules");
-        println!("# Then run: sudo udevadm control --reload-rules && sudo udevadm trigger");
-        println!();
+        eprintln!("# Razer Device Permissions");
+        eprintln!("# Save this to /etc/udev/rules.d/99-razer.rules");
+        eprintln!("# Then run: sudo udevadm control --reload-rules && sudo udevadm trigger");
+        eprintln!();
 
         // Print rules for each connected device
         for device in self.get_connected_devices() {
@@ -541,7 +542,7 @@ fn create_report(
     buf.push(0x00); // reserved
 
     #[cfg(debug_assertions)]
-    println!("Created report buffer: {:02X?}", &buf);
+    debug!("Created report buffer: {:02X?}", &buf);
 
     buf
 }
@@ -559,7 +560,7 @@ fn send_command(
     send_buf.extend(&report);
 
     #[cfg(debug_assertions)]
-    println!("Sending command buffer: {:02X?}", &send_buf);
+    debug!("Sending command buffer: {:02X?}", &send_buf);
 
     // Try to send the command
     for attempt in 0..MAX_RETRIES {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,104 @@
+use anyhow::{Context, Result};
+use directories::{BaseDirs, ProjectDirs, UserDirs};
+use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming, WriteMode};
+use log::Record;
+use std::path::PathBuf;
+
+use crate::config::LogLevel;
+
+/// Defines how the logger should output data.
+pub enum LogMode {
+    /// Log to stderr only, no files.
+    ConsoleOnly,
+    /// Log to file with rotation + stderr.
+    FileAndConsole,
+}
+
+/// Initializes the logging system.
+///
+/// Logs are written to platform-native locations:
+/// - Windows: `%LOCALAPPDATA%\razer-battery-report\logs`
+/// - Linux: `$XDG_STATE_HOME/razer-battery-report/logs`
+/// - macOS: `~/Library/Logs/razer-battery-report`
+pub fn init(cli_level: Option<LogLevel>, config_level: LogLevel, mode: LogMode) -> Result<()> {
+    let level = cli_level.unwrap_or(config_level);
+
+    let log_format =
+        |w: &mut dyn std::io::Write, now: &mut flexi_logger::DeferredNow, record: &Record| {
+            write!(
+                w,
+                "[{}] [{}] [{}] {}",
+                now.format("%Y-%m-%d %H:%M:%S"),
+                record.level(),
+                record.module_path().unwrap_or("<unnamed>"),
+                record.args()
+            )
+        };
+
+    let logger = Logger::try_with_str(level.to_string())
+        .context("Invalid log level")?
+        .format(log_format);
+
+    match mode {
+        LogMode::ConsoleOnly => {
+            logger
+                .log_to_stderr()
+                .start()
+                .context("Failed to start CLI logger")?;
+        }
+        LogMode::FileAndConsole => {
+            let project_dirs = ProjectDirs::from("", "", "razer-battery-report")
+                .context("Could not determine home directory")?;
+
+            let log_dir: PathBuf = if cfg!(target_os = "linux") {
+                // Linux: $XDG_STATE_HOME (~/.local/state/...)
+                project_dirs
+                    .state_dir()
+                    .unwrap_or_else(|| project_dirs.data_local_dir())
+                    .join("logs")
+            } else if cfg!(target_os = "macos") {
+                // macOS: ~/Library/Logs/<App>
+                if let Some(user_dirs) = UserDirs::new() {
+                    user_dirs
+                        .home_dir()
+                        .join("Library/Logs/razer-battery-report")
+                } else {
+                    // Fallback if we somehow can't find the home dir
+                    project_dirs.data_local_dir().join("logs")
+                }
+            } else {
+                // Windows: %LOCALAPPDATA%\razer-battery-report\logs
+                BaseDirs::new()
+                    .context("Could not get BaseDirs")?
+                    .data_local_dir()
+                    .join("razer-battery-report")
+                    .join("logs")
+            };
+
+            if !log_dir.exists() {
+                std::fs::create_dir_all(&log_dir).context("Failed to create log directory")?;
+            }
+
+            Logger::try_with_str(level.to_string())
+                .context(format!("Invalid log level: {}", level))?
+                .log_to_file(
+                    FileSpec::default()
+                        .directory(log_dir)
+                        .basename("razer-battery-report"),
+                )
+                // Keep last 5 files, rotate if > 1MB
+                .rotate(
+                    Criterion::Size(1_000_000),
+                    Naming::Timestamps,
+                    Cleanup::KeepLogFiles(5),
+                )
+                .duplicate_to_stderr(Duplicate::All)
+                .write_mode(WriteMode::BufferAndFlush)
+                .format(log_format)
+                .start()
+                .context("Failed to start logger")?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 // Hide console window on Windows release builds
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod cli;
 mod config;
 mod icon;
+mod logger;
 mod notification;
 mod state;
 mod tray;
@@ -10,7 +12,7 @@ mod worker;
 
 use std::{collections::HashMap, thread, time::Duration};
 
-use log::{error, info};
+use log::{debug, error, info};
 use razer_battery_report::{self as librazer};
 
 use config::AppConfig;
@@ -28,29 +30,53 @@ pub enum AppEvent {
 }
 
 fn main() -> anyhow::Result<()> {
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
+    // This allows the GUI app to print to stdout/stderr if launched from a terminal.
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
+        // We ignore the error.
+        // If it fails (e.g. launched via double-click in Explorer), we just continue as a GUI app.
+        // If it succeeds, we become a console app.
+        unsafe {
+            let _ = AttachConsole(ATTACH_PARENT_PROCESS);
+        }
     }
-    pretty_env_logger::init();
+
+    let args = cli::Args::parse();
+
+    // Earyly load config to get log_level
+    let mut config = match AppConfig::load() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Config error: {}. Using defaults.", e);
+            AppConfig::default()
+        }
+    };
+
+    logger::init(args.log_level, config.log_level, args.log_mode())?;
 
     info!("Starting Razer Battery Report...");
 
-    let mut config = match AppConfig::load() {
-        Ok(cfg) => {
-            if let Err(e) = cfg.save() {
-                error!("Failed to update config file on disk: {}", e);
-            }
-            cfg
-        }
-        Err(e) => {
-            error!("Config error: {}. Using defaults.", e);
-            let cfg = AppConfig::default();
-            if let Err(save_err) = cfg.save() {
-                error!("Failed to save default config: {}", save_err);
-            }
-            cfg
-        }
-    };
+    // Handle CLI
+    #[cfg(target_os = "linux")]
+    if args.print_udev_rules {
+        let mut context = librazer::Razer::new()?;
+        // Refresh isn't strictly necessary for printing static rules,
+        // but we want to ensure context is valid.
+        context.refresh_devices()?;
+        context.print_udev_rules();
+        return Ok(());
+    }
+
+    if args.check {
+        run_diagnostics()?;
+        return Ok(());
+    }
+
+    // Save config to disk
+    if let Err(e) = config.save() {
+        error!("Failed to update config file on disk: {}", e);
+    }
 
     // Load icons
     info!("Load icons...");
@@ -93,7 +119,7 @@ fn main() -> anyhow::Result<()> {
         match event {
             // Battery updates
             tao::event::Event::UserEvent(AppEvent::BatteryUpdate(data)) => {
-                info!("Received update: {:?}", data);
+                debug!("Received update: {:?}", data);
 
                 // Update state first
                 state_manager.process_update(&data, &config);
@@ -180,4 +206,37 @@ fn main() -> anyhow::Result<()> {
             _ => (),
         }
     });
+}
+
+fn run_diagnostics() -> anyhow::Result<()> {
+    info!("Running diagnostics...");
+    let mut context = librazer::Razer::new()?;
+    context.refresh_devices()?;
+
+    let devices = context.get_connected_devices();
+
+    if devices.is_empty() {
+        info!("No Razer devices found via HID API.");
+        return Ok(());
+    }
+
+    info!("Found {} device(s):", devices.len());
+    for device in devices {
+        info!(
+            "- Device: {} (PID: 0x{:04X})",
+            device.device_type(),
+            device.product_id
+        );
+        info!("  Path: {}", device.path);
+
+        match device.open(&context) {
+            Ok(handle) => match handle.get_battery_level() {
+                Ok(status) => info!("  Status: {}", status),
+                Err(e) => error!("  Failed to get status: {}", e),
+            },
+            Err(e) => error!("  Failed to open device: {}", e),
+        }
+    }
+
+    Ok(())
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -195,7 +195,7 @@ pub fn start_worker(
                     break;
                 }
                 Ok(WorkerCommand::Refresh) => {
-                    info!("Worker forcing refresh.");
+                    debug!("Worker forcing refresh.");
                     // Fall through to update logic immediately
                     force_update = true;
                 }


### PR DESCRIPTION
Introduce command-line interface to support debugging and configuration without modifying config files.

Replace `pretty_env_logger` with `flexi_logger` to support both console and file output modes.