### PR TITLE
Add support for Razer Basilisk V3 Pro and fix hotplug detection

### DIFF
--- a/src/devices.rs
+++ b/src/devices.rs
@@ -30,7 +30,9 @@ impl DeviceInfo {
             pid if pid == RAZER_DEATHADDER_V3_PRO_WIRED.pid
                 || pid == RAZER_DEATHADDER_V3_PRO_WIRELESS.pid
                 || pid == RAZER_DEATHADDER_V3_HYPERSPEED_WIRED.pid
-                || pid == RAZER_DEATHADDER_V3_HYPERSPEED_WIRELESS.pid =>
+                || pid == RAZER_DEATHADDER_V3_HYPERSPEED_WIRELESS.pid
+                || pid == RAZER_BASILISK_V3_PRO_WIRED.pid
+                || pid == RAZER_BASILISK_V3_PRO_WIRELESS.pid =>
             {
                 0x1F
             }
@@ -54,11 +56,18 @@ pub const RAZER_DEATHADDER_V2_PRO_WIRED: DeviceInfo =
 pub const RAZER_DEATHADDER_V2_PRO_WIRELESS: DeviceInfo =
     DeviceInfo::new("Razer DeathAdder V2 Pro (Wireless)", 0x007D, 0, 1, 2);
 
-pub const RAZER_DEVICE_LIST: [DeviceInfo; 6] = [
+pub const RAZER_BASILISK_V3_PRO_WIRED: DeviceInfo =
+    DeviceInfo::new("Razer Basilisk V3 Pro (Wired)", 0x00AA, 0, 1, 2);
+pub const RAZER_BASILISK_V3_PRO_WIRELESS: DeviceInfo =
+    DeviceInfo::new("Razer Basilisk V3 Pro (Wireless)", 0x00AB, 0, 1, 2);
+
+pub const RAZER_DEVICE_LIST: [DeviceInfo; 8] = [
     RAZER_DEATHADDER_V3_PRO_WIRED,
     RAZER_DEATHADDER_V3_PRO_WIRELESS,
     RAZER_DEATHADDER_V3_HYPERSPEED_WIRED,
     RAZER_DEATHADDER_V3_HYPERSPEED_WIRELESS,
     RAZER_DEATHADDER_V2_PRO_WIRED,
     RAZER_DEATHADDER_V2_PRO_WIRELESS,
+    RAZER_BASILISK_V3_PRO_WIRED,
+    RAZER_BASILISK_V3_PRO_WIRELESS,
 ];

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -22,6 +22,10 @@ impl DeviceManager {
     }
 
     pub fn fetch_devices(&mut self) -> (Vec<u32>, Vec<u32>) {
+        if let Err(e) = self.api.refresh_devices() {
+            warn!("Failed to refresh device list: {:?}", e);
+        }
+
         let old_ids: HashSet<u32> = self
             .device_controllers
             .lock()


### PR DESCRIPTION
Hello! I added support for the Razer Basilisk V3 Pro (Wired and Wireless) using PIDs 0x00AA and 0x00AB.

While testing, I noticed that, switching from the wireless dongle to the wire didn't detect the new connection while the app was running. I added self.api.refresh_devices() to manager.rs before fetch_devices() to fix it.