### PR TITLE
Add support for Razer Orochi V2 

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -99,6 +99,7 @@ pub struct DeviceController {
     pub pid: u16,
     pub report_id: u8,
     pub transaction_id: u8,
+    pub swappable_battery: bool
 }
 
 impl DeviceController {
@@ -113,12 +114,18 @@ impl DeviceController {
             .find(|device| device.pid == pid)
             .map_or(0x3F, |device| device.transaction_id());
 
+        let swappable_battery: bool = RAZER_DEVICE_LIST
+            .iter()
+            .find(|device| device.pid == pid)
+            .map_or(false, |device| device.swappable_battery);
+
         Ok(DeviceController {
             handle,
             name,
             pid,
             report_id: 0x00,
             transaction_id,
+            swappable_battery
         })
     }
 

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -5,6 +5,7 @@ pub struct DeviceInfo {
     pub usage_page: u16,
     pub usage: u16,
     pub vid: u16,
+    pub swappable_battery: bool // current fields do not address mice that charging isn't supported (battery mice)
 }
 
 impl DeviceInfo {
@@ -14,6 +15,7 @@ impl DeviceInfo {
         interface: u8,
         usage_page: u16,
         usage: u16,
+        swappable_battery: bool // added parameter
     ) -> Self {
         DeviceInfo {
             name,
@@ -22,6 +24,7 @@ impl DeviceInfo {
             usage_page,
             usage,
             vid: 0x1532,
+            swappable_battery
         }
     }
 
@@ -32,7 +35,9 @@ impl DeviceInfo {
                 || pid == RAZER_DEATHADDER_V3_HYPERSPEED_WIRED.pid
                 || pid == RAZER_DEATHADDER_V3_HYPERSPEED_WIRELESS.pid
                 || pid == RAZER_BASILISK_V3_PRO_WIRED.pid
-                || pid == RAZER_BASILISK_V3_PRO_WIRELESS.pid =>
+                || pid == RAZER_BASILISK_V3_PRO_WIRELESS.pid
+                || pid == RAZER_OROCHI_V2.pid
+                || pid == RAZER_OROCHI_V2_BT.pid =>
             {
                 0x1F
             }
@@ -42,31 +47,36 @@ impl DeviceInfo {
 }
 
 pub const RAZER_DEATHADDER_V3_PRO_WIRED: DeviceInfo =
-    DeviceInfo::new("Razer DeathAdder V3 Pro (Wired)", 0x00B6, 0, 1, 2);
+    DeviceInfo::new("Razer DeathAdder V3 Pro (Wired)", 0x00B6, 0, 1, 2, false);
 pub const RAZER_DEATHADDER_V3_PRO_WIRELESS: DeviceInfo =
-    DeviceInfo::new("Razer DeathAdder V3 Pro (Wireless)", 0x00B7, 0, 1, 2);
+    DeviceInfo::new("Razer DeathAdder V3 Pro (Wireless)", 0x00B7, 0, 1, 2, false);
 
 pub const RAZER_DEATHADDER_V3_HYPERSPEED_WIRED: DeviceInfo =
-    DeviceInfo::new("Razer DeathAdder V3 HyperSpeed (Wired)", 0x00C4, 0, 1, 2);
+    DeviceInfo::new("Razer DeathAdder V3 HyperSpeed (Wired)", 0x00C4, 0, 1, 2, false);
 pub const RAZER_DEATHADDER_V3_HYPERSPEED_WIRELESS: DeviceInfo =
-    DeviceInfo::new("Razer DeathAdder V3 HyperSpeed (Wireless)", 0x00C5, 0, 1, 2);
+    DeviceInfo::new("Razer DeathAdder V3 HyperSpeed (Wireless)", 0x00C5, 0, 1, 2, false);
 
 pub const RAZER_DEATHADDER_V2_PRO_WIRED: DeviceInfo =
-    DeviceInfo::new("Razer DeathAdder V2 Pro (Wired)", 0x007C, 0, 1, 2);
+    DeviceInfo::new("Razer DeathAdder V2 Pro (Wired)", 0x007C, 0, 1, 2, false);
 pub const RAZER_DEATHADDER_V2_PRO_WIRELESS: DeviceInfo =
-    DeviceInfo::new("Razer DeathAdder V2 Pro (Wireless)", 0x007D, 0, 1, 2);
+    DeviceInfo::new("Razer DeathAdder V2 Pro (Wireless)", 0x007D, 0, 1, 2, false);
 
 pub const RAZER_BASILISK_V3_PRO_WIRED: DeviceInfo =
-    DeviceInfo::new("Razer Basilisk V3 Pro (Wired)", 0x00AA, 0, 1, 2);
+    DeviceInfo::new("Razer Basilisk V3 Pro (Wired)", 0x00AA, 0, 1, 2, false);
 pub const RAZER_BASILISK_V3_PRO_WIRELESS: DeviceInfo =
-    DeviceInfo::new("Razer Basilisk V3 Pro (Wireless)", 0x00AB, 0, 1, 2);
+    DeviceInfo::new("Razer Basilisk V3 Pro (Wireless)", 0x00AB, 0, 1, 2, false);
 
 pub const RAZER_VIPER_ULTIMATE_WIRED: DeviceInfo =
-    DeviceInfo::new("Razer Viper Ultimate (Wired)", 0x007A, 0, 1, 2);
+    DeviceInfo::new("Razer Viper Ultimate (Wired)", 0x007A, 0, 1, 2, false);
 pub const RAZER_VIPER_ULTIMATE_WIRELESS: DeviceInfo =
-    DeviceInfo::new("Razer Viper Ultimate (Wireless)", 0x007B, 0, 1, 2);
+    DeviceInfo::new("Razer Viper Ultimate (Wireless)", 0x007B, 0, 1, 2, false);
 
-pub const RAZER_DEVICE_LIST: [DeviceInfo; 10] = [
+pub const RAZER_OROCHI_V2: DeviceInfo = 
+    DeviceInfo::new("Razer Orochi V2 (2.4 GHz)", 0x0094, 0, 1, 2, true);
+pub const RAZER_OROCHI_V2_BT: DeviceInfo = 
+    DeviceInfo::new("Razer Orochi V2 (Bluetooth)", 0x0095, 0, 1, 2, true);
+
+pub const RAZER_DEVICE_LIST: [DeviceInfo; 12] = [
     RAZER_DEATHADDER_V3_PRO_WIRED,
     RAZER_DEATHADDER_V3_PRO_WIRELESS,
     RAZER_DEATHADDER_V3_HYPERSPEED_WIRED,
@@ -77,4 +87,6 @@ pub const RAZER_DEVICE_LIST: [DeviceInfo; 10] = [
     RAZER_BASILISK_V3_PRO_WIRELESS,
     RAZER_VIPER_ULTIMATE_WIRED,
     RAZER_VIPER_ULTIMATE_WIRELESS,
+    RAZER_OROCHI_V2,
+    RAZER_OROCHI_V2_BT
 ];

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -69,6 +69,10 @@ impl DeviceManager {
         let controllers = self.device_controllers.lock();
         let controller = controllers.iter().find(|c| c.pid as u32 == id)?;
 
+        if controller.swappable_battery {
+            return Some(false);
+        }
+
         match controller.get_charging_status() {
             Ok(status) => Some(status),
             Err(err) => {


### PR DESCRIPTION
- Added swappable_battery boolean field to DeviceInfo to handle mice that make use of AA/AAA batteries. When true, the charging status HID command is skipped and false is returned instead, preventing "Command not supported" errors for non-rechargeable devices.

Tested on Orochi V2 (2.4 GHz) only with two different batteries (rechargeable AAA and non-rechargeable AA).
<img width="777" height="366" alt="image" src="https://github.com/user-attachments/assets/58b2562e-c084-4d8b-9bf8-4a85f08ff5e5" />

NOTE: Didn't test the bluetooth connection but I also flagged it as swappable_battery.
TODO: Battery level does not update while the Orochi V2 remains connected. Requires unplug/replug to reflect new battery level.
